### PR TITLE
feat: complete message keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,9 @@ function init(modules: { typescript: typeof import("typescript/lib/tsserverlibra
       return prior;
     }
 
+    // getCompletionsAtPosition is needed to provide the list of message keys as completion suggestions
+    // when the user triggers completion (e.g., Tab or Ctrl+Space) in the first argument of getMessage/createError/createWarning.
+    // Without this, the user will not see custom message keys as suggestions.
     proxy.getCompletionsAtPosition = (fileName, position, options) => {
       const prior = info.languageService.getCompletionsAtPosition(fileName, position, options);
       const sourceFile = info.languageService.getProgram()?.getSourceFile(fileName) as ts.SourceFile;
@@ -168,12 +171,17 @@ function init(modules: { typescript: typeof import("typescript/lib/tsserverlibra
             return prior;
           }
           const markdown = markdownLoader(messageFilePath, messageRawMarkdown);
-          const entries = Array.from(markdown.keys()).map(key => ({
-            name: key,
-            kind: ts.ScriptElementKind.string,
-            kindModifiers: '',
-            sortText: '0',
-          }));
+          const entries = Array.from(markdown.entries()).map(([key, value]) => {
+            const doc = Array.isArray(value) ? value.join('\n\n') : (typeof value === 'string' ? value : JSON.stringify(value));
+            return {
+              name: key,
+              kind: ts.ScriptElementKind.string,
+              kindModifiers: '',
+              sortText: '0',
+              // VSCode/TS supports 'documentation' for completion entry details
+              documentation: doc,
+            };
+          });
           return {
             isGlobalCompletion: false,
             isMemberCompletion: false,
@@ -183,6 +191,58 @@ function init(modules: { typescript: typeof import("typescript/lib/tsserverlibra
         }
       }
       return prior;
+    }
+
+    // getCompletionEntryDetails is needed to provide the message content as documentation/hover details
+    // when the user hovers or selects a completion entry from the list provided by getCompletionsAtPosition.
+    // Without this, the user will not see the message content as documentation for the selected key.
+    proxy.getCompletionEntryDetails = (fileName, position, entryName, formatOptions, source, preferences, data) => {
+      // Try to resolve message context for the completion entry
+      const sourceFile = info.languageService.getProgram()?.getSourceFile(fileName) as ts.SourceFile;
+      const node = tsutils.getTokenAtPosition(sourceFile, position);
+      if (node) {
+        // Try to find the context for the message key
+        if (
+          node.parent &&
+          ts.isCallExpression(node.parent) &&
+          node.parent.arguments.length > 0 &&
+          ts.isPropertyAccessExpression(node.parent.expression)
+        ) {
+          const propAccess = node.parent.expression;
+          const methodName = propAccess.name.getText();
+          if (["getMessage", "createError", "createWarning"].includes(methodName)) {
+            const varName = propAccess.expression.getText();
+            const callExpr = findMessagesLoadCall(ts, sourceFile, varName);
+            if (callExpr) {
+              const bundleMsgName = getBundleMsgName(ts, callExpr);
+              if (bundleMsgName) {
+                const messageFilePath = `${info.project.getCurrentDirectory()}/messages/${bundleMsgName}.md`;
+                let messageRawMarkdown: string;
+                try {
+                  messageRawMarkdown = readFileSync(messageFilePath, 'utf8');
+                } catch {
+                  return info.languageService.getCompletionEntryDetails(fileName, position, entryName, formatOptions, source, preferences, data);
+                }
+                const markdown = markdownLoader(messageFilePath, messageRawMarkdown);
+                const value = markdown.get(entryName);
+                if (value) {
+                  const doc = Array.isArray(value) ? value.join('\n\n') : (typeof value === 'string' ? value : JSON.stringify(value));
+                  return {
+                    name: entryName,
+                    kind: ts.ScriptElementKind.string,
+                    kindModifiers: '',
+                    displayParts: [{ text: '', kind: 'text' }],
+                    documentation: [{ text: doc, kind: 'markdown' }],
+                    tags: [],
+                  };
+                }
+              }
+            }
+          }
+        }
+      }
+      // fallback to default
+      return info.languageService.getCompletionEntryDetails(fileName, position, entryName, formatOptions, source, preferences, data);
     }
 
     return proxy;


### PR DESCRIPTION
Adds support for completing sfdx-core's message keys:

https://github.com/user-attachments/assets/38486ad1-a460-400d-a0bf-74b3979ab939



🪄 added by copilot agent in one-shot using gpt-4.1.
first commit contains changes as outputted by copilot, next commits may have manual/agent refactors.
prompt:

![Screenshot 2025-06-14 at 23 48 48](https://github.com/user-attachments/assets/cd292e22-2218-4920-b2c6-994c5a7ceda0)

then did some follow-ups to get messages as completion's descriptions.